### PR TITLE
Add PostPlayerExit Hook

### DIFF
--- a/lua/entities/gmod_door_exterior/modules/sh_players.lua
+++ b/lua/entities/gmod_door_exterior/modules/sh_players.lua
@@ -107,6 +107,10 @@ if SERVER then
 				end
 			end
 		end
+		self:CallHook("PostPlayerExit", ply, forced, notp)
+		if IsValid(self.interior) then
+			self.interior:CallHook("PostPlayerExit", ply, forced, notp)
+		end
 	end
 	
 	hook.Add("wp-shouldtp", "doors-players", function(self,ent)


### PR DESCRIPTION
Allows to use table.IsEmpty(self.occupants) to check if nobody is left inside