### PR TITLE
Only prevent interior portal teleport when it is the interior door portal, not others

### DIFF
--- a/lua/entities/gmod_door_interior/modules/sh_handleplayers.lua
+++ b/lua/entities/gmod_door_interior/modules/sh_handleplayers.lua
@@ -54,7 +54,7 @@ if SERVER then
 	end)
 
 	ENT:AddHook("ShouldTeleportPortal", "handleplayers", function(self,portal,ent)
-		if IsValid(ent) and ent:IsPlayer() and self.exterior:CallHook("CanPlayerExit",ent)==false then
+		if IsValid(ent) and ent:IsPlayer() and portal==self.portals.interior and self.exterior:CallHook("CanPlayerExit",ent)==false then
 			return false
 		end
 	end)


### PR DESCRIPTION
This caused a bug in certain TARDIS interiors that have secondary portals for linking corridors etc like the 2010 TARDIS to prevent portal teleporting while in the vortex.