### PR TITLE
OnRemove: remove entities from the inside

### DIFF
--- a/lua/entities/gmod_door_interior/modules/sh_handleplayers.lua
+++ b/lua/entities/gmod_door_interior/modules/sh_handleplayers.lua
@@ -67,6 +67,20 @@ if SERVER then
             end
         end
     end)
+
+    ENT:AddHook("OnRemove","inside_entities",function(self)
+        local inside_entities = ents.FindInBox(self:LocalToWorld(self:OBBMins()), self:LocalToWorld(self:OBBMaxs()))
+
+        for i,v in ipairs(inside_entities) do
+            local cl = v:GetClass()
+            if cl == "prop_physics" or cl == "prop_ragdoll" or v:IsNPC()
+                or string.StartsWith(cl, "weapon_")
+            then
+                v:Remove()
+            end
+        end
+    end)
+
 else
     ENT:AddHook("ShouldDraw", "handleplayers", function(self)
         if (LocalPlayer().doori~=self) and not wp.drawing and not self.contains[LocalPlayer().door] then


### PR DESCRIPTION
Migrated from https://github.com/MattJeanes/TARDIS/pull/832

Added removing props and NPCs from the TARDIS when removed

I wanted to make it work for all entities, but it starts removing weapons from players inside and causes lots of issues I couldn't resolve even by filtering entity types, so let's stick to this

UPD: ragdolls and weapons were also added
