### PR TITLE
Fixed propscan being nil and tried to be compared

### DIFF
--- a/lua/entities/gmod_door_interior/modules/sh_cordon.lua
+++ b/lua/entities/gmod_door_interior/modules/sh_cordon.lua
@@ -98,7 +98,7 @@ end)
 
 if CLIENT then
     ENT:AddHook("Think", "cordon", function(self)
-        if CurTime()>self.propscan then
+        if self.propscan ~= nil and CurTime()>self.propscan then
             self.propscan=CurTime()+1
             self:UpdateCordon()
         end


### PR DESCRIPTION
Constantly caused this error on the client:

```
[Doors] lua/entities/gmod_door_interior/modules/sh_cordon.lua:101: attempt to compare nil with number
  1. v - lua/entities/gmod_door_interior/modules/sh_cordon.lua:101
   2. CallHook - lua/entities/gmod_door_interior/shared.lua:31
    3. CallHook - lua/entities/gmod_tardis_interior/shared.lua:43
     4. unknown - lua/entities/gmod_door_interior/cl_init.lua:45 (x89)
```