### PR TITLE
Added a small unstick feature to portals to prevent getting stuck in the floor

### DIFF
--- a/lua/doors/sh_hooks.lua
+++ b/lua/doors/sh_hooks.lua
@@ -33,4 +33,11 @@ else
             end
         end
     end)
+    hook.Add("PreDrawTranslucentRenderables", "doors-i", function()
+        for k,v in pairs(Doors:GetInteriors()) do
+            if IsValid(k) then
+                k:CallHook("PreDrawTranslucentRenderables")
+            end
+        end
+    end)
 end

--- a/lua/entities/gmod_door_interior/modules/sh_handleplayers.lua
+++ b/lua/entities/gmod_door_interior/modules/sh_handleplayers.lua
@@ -22,6 +22,49 @@ function ENT:IsStuck(ply)
     return tr.Hit
 end
 
+function ENT:IsThisSafe(plybox) -- Uses a fake player hitbox to check subsequent spots as actually teleporting the player causes camera issues
+    local pos=plybox.pos
+    local td={}
+    td.start=pos
+    td.endpos=pos
+    td.mins=plybox.mins
+    td.maxs=plybox.maxs
+    td.filter={plybox,unpack(self.stuckfilter)}
+    local tr=util.TraceHull(plybox)
+    return tr.Hit
+end
+
+function ENT:UnStick(ply, portal)
+    -- print("Unsticking!")
+    local pos=ply:GetPos()
+    local plybox={}
+    plybox.start=pos
+    plybox.endpos=pos
+    plybox.mins=ply:OBBMins()
+    plybox.maxs=ply:OBBMaxs()
+    plybox.filter={ply,unpack(self.stuckfilter)}
+    local distance = Vector(0, 0, 0)
+    while self:IsThisSafe(plybox) and (distance.z < 10) do -- Distance limit is 10 units, if greater it'll use the fallback instead
+        plybox.mins = (plybox.mins + Vector(0, 0, 1)) --2 instead of just 1 as it has a less chance of failing
+        plybox.maxs = (plybox.maxs + Vector(0, 0, 1))
+        distance = (distance + Vector(0, 0, 1))
+    end
+    -- print(distance)
+    if (distance.z < 10) then
+        ply:SetPos(ply:GetPos()+distance)
+    end
+    if (distance.z >= 10) and self:IsStuck(ply) then
+        -- print("Failed to unstick, using fallback")
+        if IsValid(portal) and portal==self.portals.interior and self:IsStuck(ply) then
+            self.exterior:PlayerEnter(ply)
+            self.exterior:PlayerExit(ply)
+        elseif IsValid(portal) and portal==self.portals.exterior and self:IsStuck(ply) then
+            self.exterior:PlayerExit(ply)
+            self.exterior:PlayerEnter(ply)
+        end
+    end
+end
+
 if SERVER then
     function ENT:CheckPlayer(ply,portal)
         local inbox = self:PositionInside(ply:GetPos())
@@ -30,8 +73,7 @@ if SERVER then
             self.exterior:PlayerExit(ply,true,IsValid(portal))
             if IsValid(portal) and portal==self.portals.interior and self:IsStuck(ply) then
                 --print("stuck out",self,ply,portal)
-                self.exterior:PlayerEnter(ply)
-                self.exterior:PlayerExit(ply)
+                self:UnStick(ply, portal)
             end
             if IsValid(portal) and IsValid(portal.interior) and portal.interior.DoorInterior then
                 portal.interior:CheckPlayer(ply)
@@ -41,8 +83,7 @@ if SERVER then
             self.exterior:PlayerEnter(ply,true)
             if IsValid(portal) and portal==self.portals.exterior and self:IsStuck(ply) then
                 --print("stuck in",self,ply,portal)
-                self.exterior:PlayerExit(ply)
-                self.exterior:PlayerEnter(ply)
+                self:UnStick(ply, portal)
             end
         end
     end


### PR DESCRIPTION
with this change it will now try to move the player up (to a limit of 10 units) before resorting to the fallback option, not only does this improve the seamlessness of the HUGE amount of tardises, but it also fixes a long term issue with safe spaces causing you to consistently get stuck in the floor since that doesn't even have a fallback

feel free to clean this up however you see fit before implementation, im sure theres probably something i didn't think of that might streamline it