### PR TITLE
Fix flashing and low ceiling incompatibility

### DIFF
--- a/lua/entities/gmod_door_interior/modules/sh_handleplayers.lua
+++ b/lua/entities/gmod_door_interior/modules/sh_handleplayers.lua
@@ -28,15 +28,29 @@ function ENT:IsStuck(ply)
     return tr.Hit
 end
 
+function ENT:IsThisSafe(ply, dist) -- Checking in advance to teleporting as actually using the player, this is because teleporting the player then teleporting again to the fallback location causes flashing
+    local pos=ply:GetPos() + dist
+    local td={}
+    td.start=pos
+    td.endpos=pos
+    td.mins=ply:OBBMins()
+    td.maxs=ply:OBBMaxs()
+    td.filter={ply,unpack(self.stuckfilter)}
+    local tr=util.TraceHull(td)
+    return !tr.Hit
+end
+
 function ENT:UnStick(ply, portal, exiting)
     local pos=ply:GetPos()
     local td=self:GetStuckTrace(ply)
+    td.maxs.z=td.mins.z -- Ignore head height for the snapping to floor bit to avoid conflicting with low ceilings
     td.start = td.start + Vector(0,0,10)
     local tr = util.TraceHull(td)
-    if tr.HitPos then
+    local dist = tr.HitPos - pos
+    print(dist)
+    if tr.HitPos and self:IsThisSafe(ply, dist) then
         ply:SetPos(tr.HitPos)
-    end
-    if self:IsStuck(ply) then
+    else
         if exiting then
             self.exterior:PlayerEnter(ply)
             self.exterior:PlayerExit(ply)


### PR DESCRIPTION
This fixes both the issue with the screen flashing when resorting to the fallback, and an issue where interiors/exteriors with very low ceilings would be forced to use the fallback despite having valid locations

the flashing was caused by teleporting the player to the unstick position then teleporting to the fallback location, this causes the screen to briefely flash, to combat this i just made it check if the location is safe before teleporting instead of checking after

the low ceiling fix was done by just flattening the trace hull specifically for the bit where its snapped to the floor since player height data is not required for that part, it will still check the full hitbox when making sure its a safe location to teleport to so it won't cause any issues with getting stuck, just allows for less use of the fallback