### PR TITLE
ConVar for interior attempt amount

### DIFF
--- a/lua/entities/gmod_door_exterior/modules/sh_interior.lua
+++ b/lua/entities/gmod_door_exterior/modules/sh_interior.lua
@@ -1,6 +1,6 @@
 -- Adds an interior
 
-
+CreateConVar("doors_interior_tries", 10000, {FCVAR_ARCHIVE, FCVAR_REPLICATED, FCVAR_NOTIFY}, "Doors - How many tries to find a valid interior placement")
 
 if SERVER then
     function ENT:FindPosition(e)
@@ -16,7 +16,7 @@ if SERVER then
         td.maxs=e.maxs or e:OBBMaxs()
         td.mask=MASK_PLAYERSOLID
         local max=16384
-        local tries=10000
+        local tries=GetConVar("doors_interior_tries"):GetInt()
         local targetframetime=1/30
         local nowhere
         local highest


### PR DESCRIPTION
added a serverside convar for how many attempts the interior will make to find a valid location, useful for crampt maps that do actually have space for an interior, but only barely